### PR TITLE
feat(branch-restriction): return http error model for post

### DIFF
--- a/api_branch_restrictions.go
+++ b/api_branch_restrictions.go
@@ -12,11 +12,12 @@ package bitbucket
 import (
 	"context"
 	"fmt"
-	"github.com/antihax/optional"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/antihax/optional"
 )
 
 // Linger please
@@ -566,127 +567,42 @@ Creates a new branch restriction rule for a repository.  &#x60;kind&#x60; descri
 
 @return Branchrestriction
 */
-func (a *BranchRestrictionsApiService) RepositoriesWorkspaceRepoSlugBranchRestrictionsPost(ctx context.Context, body Branchrestriction, repoSlug string, workspace string) (Branchrestriction, *http.Response, error) {
-	var (
-		localVarHttpMethod  = strings.ToUpper("Post")
-		localVarPostBody    interface{}
-		localVarFileName    string
-		localVarFileBytes   []byte
-		localVarReturnValue Branchrestriction
-	)
-
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/repositories/{workspace}/{repo_slug}/branch-restrictions"
-	localVarPath = strings.Replace(localVarPath, "{"+"repo_slug"+"}", fmt.Sprintf("%v", repoSlug), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"workspace"+"}", fmt.Sprintf("%v", workspace), -1)
-
+func (a *BranchRestrictionsApiService) RepositoriesWorkspaceRepoSlugBranchRestrictionsPost(ctx context.Context, body Branchrestriction, repoSlug string, workspace string) (*Branchrestriction, *http.Response, *GenericSwaggerError, error) {
+	localVarPath := fmt.Sprintf("%v/repositories/%v/%v/branch-restrictions", a.client.cfg.BasePath, workspace, repoSlug)
 	localVarHeaderParams := make(map[string]string)
-	localVarQueryParams := url.Values{}
-	localVarFormParams := url.Values{}
+	localVarHeaderParams["Accept"] = "application/json"
 
-	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{"application/json"}
-
-	// set Content-Type header
-	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
-	if localVarHttpContentType != "" {
-		localVarHeaderParams["Content-Type"] = localVarHttpContentType
-	}
-
-	// to determine the Accept header
-	localVarHttpHeaderAccepts := []string{"application/json"}
-
-	// set Accept header
-	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
-	if localVarHttpHeaderAccept != "" {
-		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
-	}
-	// body params
-	localVarPostBody = &body
-	if ctx != nil {
-		// API Key Authentication
-		if auth, ok := ctx.Value(ContextAPIKey).(APIKey); ok {
-			var key string
-			if auth.Prefix != "" {
-				key = auth.Prefix + " " + auth.Key
-			} else {
-				key = auth.Key
-			}
-			localVarHeaderParams["Authorization"] = key
-
-		}
-	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	r, err := a.client.prepareRequest(ctx, localVarPath, http.MethodPost, &body, localVarHeaderParams, url.Values{}, url.Values{}, "", []byte{})
 	if err != nil {
-		return localVarReturnValue, nil, err
+		return nil, nil, nil, err
 	}
 
 	localVarHttpResponse, err := a.client.callAPI(r)
-	if err != nil || localVarHttpResponse == nil {
-		return localVarReturnValue, localVarHttpResponse, err
+	if err != nil {
+		return nil, localVarHttpResponse, nil, err
 	}
+	defer localVarHttpResponse.Body.Close()
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
-	localVarHttpResponse.Body.Close()
 	if err != nil {
-		return localVarReturnValue, localVarHttpResponse, err
+		return nil, localVarHttpResponse, nil, err
 	}
 
-	if localVarHttpResponse.StatusCode < 300 {
-		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-		if err == nil {
-			return localVarReturnValue, localVarHttpResponse, err
-		}
+	var localVarReturnValue Branchrestriction
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, localVarHttpResponse, nil, err
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
+		var v ModelError
 		newErr := GenericSwaggerError{
 			body:  localVarBody,
 			error: localVarHttpResponse.Status,
+			model: v,
 		}
-		if localVarHttpResponse.StatusCode == 201 {
-			var v Branchrestriction
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
-		if localVarHttpResponse.StatusCode == 401 {
-			var v ModelError
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
-		if localVarHttpResponse.StatusCode == 403 {
-			var v ModelError
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
-		if localVarHttpResponse.StatusCode == 404 {
-			var v ModelError
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
-		return localVarReturnValue, localVarHttpResponse, newErr
+		return &localVarReturnValue, localVarHttpResponse, &newErr, nil
 	}
 
-	return localVarReturnValue, localVarHttpResponse, nil
+	return &localVarReturnValue, localVarHttpResponse, nil, nil
 }

--- a/client.go
+++ b/client.go
@@ -363,6 +363,17 @@ func (c *APIClient) prepareRequest(
 		if auth, ok := ctx.Value(ContextAccessToken).(string); ok {
 			localVarRequest.Header.Add("Authorization", "Bearer "+auth)
 		}
+
+		// API Key Authentication
+		if auth, ok := ctx.Value(ContextAPIKey).(APIKey); ok {
+			var key string
+			if auth.Prefix != "" {
+				key = auth.Prefix + " " + auth.Key
+			} else {
+				key = auth.Key
+			}
+			localVarRequest.Header.Add("Authorization", key)
+		}
 	}
 
 	for header, value := range c.cfg.DefaultHeader {


### PR DESCRIPTION
Related to https://github.com/DrFaust92/terraform-provider-bitbucket/issues/93

This PR is a PoC to handle the Bitbucket HTTP calls, building upon the dynamic decoding of the body (`client.decode()`). I also removed a lot of boilerplate/unnecessary code to keep the code a bit smaller. I will comment in my files, the reasoning for it.

The basic set up is that we return the `GenericSwaggerError` object whenever the status code is bigger than 300. 

@DrFaust92 If you think this set up is good enough, I would like to apply it to the other affected functions. I am aware there is also swagger-codegen definition, of which I am not that familiar with. If his code should actually be auto-generated, then please let me know.

----

See https://github.com/DrFaust92/terraform-provider-bitbucket/pull/125 for on implementation of this.
