### PR TITLE
chore(codegen): make sure package is set to bitbucket generated code

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,4 +7,4 @@ build:
 	go build
 
 generate:
-	swagger-codegen generate -i  https://api.bitbucket.org/swagger.json -l go -c swagger.conf
+	swagger-codegen generate -i https://api.bitbucket.org/swagger.json -l go -c swagger.conf --additional-properties packageName=bitbucket


### PR DESCRIPTION
While playing around with the swagger-codegen tool, I noticed the package name was set to "swagger" (`package swagger`) on every api and model file. Using `--additional-properties packageName=bitbucket` apparently fixes this, and correctly sets `package bitbucket` to all files.