### PR TITLE
fix(pipeline_config): fix model template bool property

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -11,4 +11,4 @@ patch:
 	wget -q --output-document - https://api.bitbucket.org/swagger.json | "$$(go env GOPATH)/bin/json-patch" -p api/swagger.json-patch > api/swagger.output.json
 
 generate: patch
-	swagger-codegen generate -i api/swagger.output.json -l go -c swagger.conf --additional-properties packageName=bitbucket
+	swagger-codegen generate -i api/swagger.output.json -l go -c swagger.conf --additional-properties packageName=bitbucket --template-dir swagger-template

--- a/model_pipelines_config.go
+++ b/model_pipelines_config.go
@@ -10,8 +10,8 @@
 package bitbucket
 
 type PipelinesConfig struct {
-	Type_ string `json:"type"`
 	// Whether Pipelines is enabled for the repository.
-	Enabled    bool        `json:"enabled,omitempty"`
+	Enabled    *bool       `json:"enabled,omitempty"`
 	Repository *Repository `json:"repository,omitempty"`
+	Type_      string      `json:"type"`
 }

--- a/swagger-template/model.mustache
+++ b/swagger-template/model.mustache
@@ -1,0 +1,43 @@
+{{>partial_header}}
+package {{packageName}}
+{{#models}}
+{{#imports}}
+{{#@first}}
+import (
+{{/@first}}
+	"{{import}}"
+{{#@last}}
+)
+{{/@last}}
+{{/imports}}
+{{#model}}{{#isEnum}}{{#description}}// {{{classname}}} : {{{description}}}{{/description}}
+type {{{classname}}} {{^format}}{{dataType}}{{/format}}{{#format}}{{{format}}}{{/format}}
+
+// List of {{{name}}}
+const (
+	{{#allowableValues}}
+	{{#enumVars}}
+	{{^@first}}
+	{{/@first}}
+	{{name}}_{{{classname}}} {{{classname}}} = "{{{value}}}"
+	{{/enumVars}}
+	{{/allowableValues}}
+){{/isEnum}}{{^isEnum}}{{#description}}
+// {{{description}}}{{/description}}
+type {{classname}} struct {
+{{#isComposedModel}}
+    {{#interfaceModels}}
+    {{classname}}
+    {{/interfaceModels}}
+{{/isComposedModel}}
+{{^isComposedModel}}
+{{#vars}}
+{{^@first}}
+{{/@first}}
+{{#description}}
+	// {{{description}}}
+{{/description}}
+	{{name}} {{^isEnum}}{{^isPrimitiveType}}{{^isContainer}}{{^isDateTime}}*{{/isDateTime}}{{/isContainer}}{{/isPrimitiveType}}{{/isEnum}}{{#isBoolean}}*{{/isBoolean}}{{{datatype}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}"{{/withXml}}`
+{{/vars}}
+{{/isComposedModel}}
+}{{/isEnum}}{{/model}}{{/models}}


### PR DESCRIPTION
This PR fixes the boolean type definition of all models by transforming them into a pointer boolean. 

**Underlying issue**
Whenever a boolean value is `false` and it is not required, the `omitempty` serialization property will omit this property. In cases where an entity needs to be disabled through a `false` status, this is not the desired result. Instead, we always want to send `true/false` value, but omit when it is not explicitly set. Through a pointer, when the value is not defined, it will be set to `nil` and only then will be omitted from the API call.

**Upstream**
The issue is related to the generator used, and a very old issue is open for this: https://github.com/swagger-api/swagger-codegen/issues/7391

I have sent an upstream Pull Request: https://github.com/swagger-api/swagger-codegen-generators/pull/1275

As I do not expect this Pull Request to be merged any time soon (there has not been a Go update in 4 years), I added the same patch in this repo as a custom template. This template can be removed once upstream has been merged.

----

Related to https://github.com/DrFaust92/terraform-provider-bitbucket/issues/191, and some other mentioned issues. 
Once this has been merged, I will go through the related issues and add regression tests where it is needed.